### PR TITLE
Update Sonar Scanner to 3.2.0.1227

### DIFF
--- a/sonarcube-scanner/sonarcube-scanner.nuspec
+++ b/sonarcube-scanner/sonarcube-scanner.nuspec
@@ -3,7 +3,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>sonarcube-scanner</id>
-    <version>3.0.3.778</version>
+    <version>3.2.0.1227</version>
     <title>SonarQube Scanner</title>
     <summary>Official SonarQube Scanner used to start code analysis.</summary>
     <description>Official SonarQube Scanner used to start code analysis.</description>
@@ -11,7 +11,7 @@
     <projectSourceUrl>https://github.com/SonarSource/sonar-scanner-cli</projectSourceUrl>
     <docsUrl>http://docs.sonarqube.org/display/SONAR/Analyzing+with+SonarQube+Scanner</docsUrl>
     <bugTrackerUrl>http://jira.sonarsource.com/browse/SQSCANNER</bugTrackerUrl>
-    <copyright>2008-2017, SonarSource S.A, Switzerland</copyright>
+    <copyright>2008-2018, SonarSource S.A, Switzerland</copyright>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <authors>SonarQube</authors>
     <owners>Roemer</owners>

--- a/sonarcube-scanner/tools/chocolateyinstall.ps1
+++ b/sonarcube-scanner/tools/chocolateyinstall.ps1
@@ -1,8 +1,8 @@
 ﻿$packageName = 'sonarcube-scanner'
 $toolsDir = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
-$url = 'https://sonarsource.bintray.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-3.0.3.778.zip'
+$url = 'https://sonarsource.bintray.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-3.2.0.1227.zip'
 $checksumType = 'sha256'
-$checksum = '4E3035F208548621433C8713DE5E536AA81AE1AB4DF2998E041B9236B3BA3170'
+$checksum = 'f0e05102a3e98aceb141577c08896c49e3bff9520d1e2f75a688a0ce0d099bc0'
 Install-ChocolateyZipPackage $packageName $url $toolsDir -Checksum $checksum -ChecksumType $checksumType
-Install-BinFile "sonar-runner" "$toolsDir\sonar-scanner-3.0.3.778\bin\sonar-runner.bat"
-Install-BinFile "sonar-scanner" "$toolsDir\sonar-scanner-3.0.3.778\bin\sonar-scanner.bat"
+Install-BinFile "sonar-runner" "$toolsDir\sonar-scanner-3.2.0.1227\bin\sonar-runner.bat"
+Install-BinFile "sonar-scanner" "$toolsDir\sonar-scanner-3.2.0.1227\bin\sonar-scanner.bat"


### PR DESCRIPTION
The version of the Sonar Scanner CLI needs updating to keep track with the most recent version.

Not worked with the packages before so hopefully the changes included are all that are needed for it.