### PR TITLE
Deprecate nunit package

### DIFF
--- a/nunit-console.portable/nunit-console.portable.nuspec
+++ b/nunit-console.portable/nunit-console.portable.nuspec
@@ -3,10 +3,10 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>nunit-console.portable</id>
-    <version>3.6.1</version>
-    <title>NUnit Console (Portable)</title>
+    <version>3.6.1.20180720</version>
+    <title>[Deprecated] NUnit Console (Portable)</title>
     <summary>NUnit Console runner and test engine</summary>
-    <description>NUnit Console runner and test engine</description>
+    <description>This package is deprecated in favour of the [NUnit 3 Console Runner](https://chocolatey.org/packages/nunit-console-runner) package released by The NUnit Organization.</description>
     <projectUrl>https://github.com/nunit/nunit-console</projectUrl>
     <projectSourceUrl>https://github.com/nunit/nunit-console</projectSourceUrl>
     <docsUrl>https://github.com/nunit/docs/wiki/Console-Command-Line</docsUrl>
@@ -18,7 +18,8 @@
     <tags>nunit console runner</tags>
     <packageSourceUrl>https://github.com/Roemer/Chocolatey-Packages</packageSourceUrl>
   </metadata>
-  <files>
-    <file src="tools\**" target="tools" />
-  </files>
+  <dependencies>
+    <dependency id="nunit-console-runner" />
+  </dependencies>
+  <files />
 </package>

--- a/nunit-console.portable/tools/chocolateyInstall.ps1
+++ b/nunit-console.portable/tools/chocolateyInstall.ps1
@@ -1,6 +1,0 @@
-﻿$packageName = 'nunit-console.portable'
-$toolsDir = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
-$url = 'https://github.com/nunit/nunit-console/releases/download/3.6.1/NUnit.Console-3.6.1.zip'
-$checksumType = 'sha256'
-$checksum = '3A177506699282D5C9E720BE8BAB8F9C0CB925E0E78ACD335FBF6798B7095648'
-Install-ChocolateyZipPackage $packageName $url $toolsDir -Checksum $checksum -ChecksumType $checksumType


### PR DESCRIPTION
Fixes https://github.com/Roemer/Chocolatey-Packages/issues/7.

I think this is everything required - I've followed the steps listed [here](https://chocolatey.org/docs/how-to-deprecate-a-chocolatey-package), and the work one of the chocolatey core team did to a similar NUnit package [here](https://github.com/dtgm/chocolatey-packages/commit/a66bf6619764fdbe657b74b880a249bcc0cd1243).

The final steps, that I believe will need to be done by hand are...

- [Publish] a new version of the deprecated Chocolatey Package.
- Unlist all versions from the package gallery, **except** the final deprecated version. The final deprecated version is required so that there is an update path to the new package.
By following this process, any existing users who try to update the old package will automatically get the new package, as it will be installed as a dependency.

Thanks for putting this package online in the first place - it did take us at NUnit a while to get round to building choco into our build process - but we got there in the end. Hopefully this change should give automatic, up-to-the-minute updates for everyone from now on! 😄 