### PR TITLE
Update sonarcube-scanner to 3.2.0.1227

### DIFF
--- a/sonarcube-scanner/sonarcube-scanner.nuspec
+++ b/sonarcube-scanner/sonarcube-scanner.nuspec
@@ -3,7 +3,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>sonarcube-scanner</id>
-    <version>3.0.3.778</version>
+    <version>3.2.0.1227</version>
     <title>SonarQube Scanner</title>
     <summary>Official SonarQube Scanner used to start code analysis.</summary>
     <description>Official SonarQube Scanner used to start code analysis.</description>
@@ -11,7 +11,7 @@
     <projectSourceUrl>https://github.com/SonarSource/sonar-scanner-cli</projectSourceUrl>
     <docsUrl>http://docs.sonarqube.org/display/SONAR/Analyzing+with+SonarQube+Scanner</docsUrl>
     <bugTrackerUrl>http://jira.sonarsource.com/browse/SQSCANNER</bugTrackerUrl>
-    <copyright>2008-2017, SonarSource S.A, Switzerland</copyright>
+    <copyright>2008-2018, SonarSource S.A, Switzerland</copyright>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <authors>SonarQube</authors>
     <owners>Roemer</owners>

--- a/sonarcube-scanner/tools/chocolateyUninstall.ps1
+++ b/sonarcube-scanner/tools/chocolateyUninstall.ps1
@@ -1,2 +1,1 @@
-Uninstall-BinFile "sonar-runner"
 Uninstall-BinFile "sonar-scanner"

--- a/sonarcube-scanner/tools/chocolateyinstall.ps1
+++ b/sonarcube-scanner/tools/chocolateyinstall.ps1
@@ -1,8 +1,7 @@
 ﻿$packageName = 'sonarcube-scanner'
 $toolsDir = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
-$url = 'https://sonarsource.bintray.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-3.0.3.778.zip'
+$url = 'https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-3.2.0.1227-windows.zip'
 $checksumType = 'sha256'
-$checksum = '4E3035F208548621433C8713DE5E536AA81AE1AB4DF2998E041B9236B3BA3170'
+$checksum = '5CC23EE0CB8E8B09793EEF05CFB1B091EE05265E275A89846E476E630E087E05'
 Install-ChocolateyZipPackage $packageName $url $toolsDir -Checksum $checksum -ChecksumType $checksumType
-Install-BinFile "sonar-runner" "$toolsDir\sonar-scanner-3.0.3.778\bin\sonar-runner.bat"
-Install-BinFile "sonar-scanner" "$toolsDir\sonar-scanner-3.0.3.778\bin\sonar-scanner.bat"
+Install-BinFile "sonar-scanner" "$toolsDir\sonar-scanner-3.2.0.1227-windows\bin\sonar-scanner.bat"


### PR DESCRIPTION
Pull request #6 is invalid because:

- `sonar-runner` was removed;
- They moved away from bintray (invalid link);
- The directory structure of the zip changed.