### PR TITLE
Upgrade to flyway 6.0.0 beta

### DIFF
--- a/flyway.commandline.withjre/flyway.commandline.withjre.nuspec
+++ b/flyway.commandline.withjre/flyway.commandline.withjre.nuspec
@@ -3,7 +3,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>flyway.commandline.withjre</id>
-    <version>6.0.0-beta</version>
+    <version>6.0.0-beta2</version>
     <title>Flyway (with JRE)</title>
     <summary>Flyway is database-independent library for tracking, managing and applying database changes</summary>
     <description>Flyway is database-independent library for tracking, managing and applying database changes</description>

--- a/flyway.commandline.withjre/tools/chocolateyInstall.ps1
+++ b/flyway.commandline.withjre/tools/chocolateyInstall.ps1
@@ -1,8 +1,8 @@
-﻿$version = '6.0.0-beta'
+﻿$version = '6.0.0-beta2'
 $packageName = 'flyway.commandline.withjre'
 $toolsDir = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 $url = "https://repo1.maven.org/maven2/org/flywaydb/flyway-commandline/$version/flyway-commandline-$version-windows-x64.zip"        
 $checksumType = 'sha256'
-$checksum = '2521588ef2af3b93394fef88c9c3a382d43c9a25a8db3f7a7ad935add6032bd9'
+$checksum = '19229da5ab1248b712c33757f56a3801b285826b3d5490da531ff648955cd574'
 Install-ChocolateyZipPackage $packageName $url $toolsDir -Checksum $checksum -ChecksumType $checksumType
 Install-BinFile "flyway" "$toolsDir\flyway-$version\flyway.cmd"

--- a/flyway.commandline/flyway.commandline.nuspec
+++ b/flyway.commandline/flyway.commandline.nuspec
@@ -3,7 +3,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>flyway.commandline</id>
-    <version>6.0.0-beta</version>
+    <version>6.0.0-beta2</version>
     <title>Flyway</title>
     <summary>Flyway is database-independent library for tracking, managing and applying database changes</summary>
     <description>Flyway is database-independent library for tracking, managing and applying database changes</description>

--- a/flyway.commandline/tools/chocolateyInstall.ps1
+++ b/flyway.commandline/tools/chocolateyInstall.ps1
@@ -1,8 +1,8 @@
-﻿$version = '6.0.0-beta'
+﻿$version = '6.0.0-beta2'
 $packageName = 'flyway.commandline'
 $toolsDir = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 $url = "https://repo1.maven.org/maven2/org/flywaydb/flyway-commandline/$version/flyway-commandline-$version.zip"
 $checksumType = 'sha256'
-$checksum = '9a222b634da2636dfe1f9b4e561b56713c24ce3ed4da246a2907144c1d2a7740'
+$checksum = '73c38a8534dc035e7703c49c5bc234deaf09110b2151f3b4923619400273581f'
 Install-ChocolateyZipPackage $packageName $url $toolsDir -Checksum $checksum -ChecksumType $checksumType
 Install-BinFile "flyway" "$toolsDir\flyway-$version\flyway.cmd"


### PR DESCRIPTION
Since chocolatey won't automatically update anything with a `-` in the version number, this can be safely pushed to the repo. 

For those who specifically want to upgrade, they have to specify `--pre` during installation or upgrade.