### PR TITLE
check for existing install version match

### DIFF
--- a/sqlserver-odbcdriver/tools/chocolateyinstall.ps1
+++ b/sqlserver-odbcdriver/tools/chocolateyinstall.ps1
@@ -6,4 +6,15 @@ $url64 = '{link64}'
 $checksumType = 'sha256'
 $checksum = '{checksum32}'
 $checksum64 = '{checksum64}'
-Install-ChocolateyPackage "$packageName" "$installerType" "$silentArgs" "$url" "$url64" -validExitCodes @(0) "$checksum" "$checksumType" "$checksum64" "$checksumType"
+
+$32DllPath = Join-Path -Path $Env:SystemRoot -ChildPath (Join-Path -Path 'system32' -ChildPath 'msodbcsql18.dll')
+$64DllPath = Join-Path -Path $Env:SystemRoot -ChildPath (Join-Path -Path 'syswow64' -ChildPath 'msodbcsql18.dll')
+$32BitNeeded = ([Version]$(Get-ItemProperty -Path $32DllPath -ErrorAction:Ignore).VersionInfo.ProductVersion) -lt [Version]$Env:ChocolateyPackageVersion  
+$64BitNeeded = ([Version]$(Get-ItemProperty -Path $64DllPath -ErrorAction:Ignore).VersionInfo.ProductVersion) -lt [Version]$Env:ChocolateyPackageVersion
+
+$UpdateNeeded = ($32BitNeeded -or $64BitNeeded -or $Env:ChocolateyForce)
+
+if ($UpdateNeeded)
+{
+  Install-ChocolateyPackageCmdlet "$packageName" "$installerType" "$silentArgs" "$url" "$url64" -validExitCodes @(0) "$checksum" "$checksumType" "$checksum64" "$checksumType" -UseOriginalLocation
+}


### PR DESCRIPTION
if the package version is not already present, proceed with install, else exit and mark package install success

If the package is run against a machine that already has this or a later version of the `ODBC Driver 18 for SQL Server` installed, the install will fail with an exit code of 1603.  Instead of allowing the package the fail, check to see if the drivers are already present and run the install command only if/when necessary.

This will allow new or existing chocolatey users to transition to this package without causing errors, and will also prevent errors if the driver was installed outside of chocolatey using some other patching mechanism.