### PR TITLE
Limit SQL Server ODBC Driver to v17

### DIFF
--- a/sqlserver-cmdlineutils/sqlserver-cmdlineutils.nuspec
+++ b/sqlserver-cmdlineutils/sqlserver-cmdlineutils.nuspec
@@ -14,7 +14,7 @@
     <tags>sqlserver sql sqlcmd commandline utilities</tags>
     <packageSourceUrl>https://github.com/Roemer/chocolatey-packages</packageSourceUrl>
     <dependencies>
-      <dependency id="sqlserver-odbcdriver-17" version="17.5.2.1" />
+      <dependency id="sqlserver-odbcdriver-17" version="17.10.5.1" />
     </dependencies>
   </metadata>
   <files>

--- a/sqlserver-cmdlineutils/sqlserver-cmdlineutils.nuspec
+++ b/sqlserver-cmdlineutils/sqlserver-cmdlineutils.nuspec
@@ -14,7 +14,7 @@
     <tags>sqlserver sql sqlcmd commandline utilities</tags>
     <packageSourceUrl>https://github.com/Roemer/chocolatey-packages</packageSourceUrl>
     <dependencies>
-      <dependency id="sqlserver-odbcdriver" version="17.5.2.1" />
+      <dependency id="sqlserver-odbcdriver-17" version="17.5.2.1" />
     </dependencies>
   </metadata>
   <files>


### PR DESCRIPTION
SQL command line utils [won't work with ODBC driver v18](https://community.chocolatey.org/packages/sqlserver-cmdlineutils#comment-6349304903), so we need to limit the installation to v17.

Since now we have [the split packages](https://github.com/Roemer/chocolatey-packages/issues/32) this should be as trivial as just referencing the right one.