### PR TITLE
Update flyway to 10.18.1

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -34,7 +34,7 @@ Task("Pack-Flyway")
     .IsDependentOn("Clean-Output")
     .Does(() =>
 {
-    var version = "10.17.0";
+    var version = "10.18.1";
 
     // Handle the file without jre
     {


### PR DESCRIPTION
* Updating flyway to 10.18.1 to fix Azure ActiveDirectory Authentication errors.